### PR TITLE
Upgrade adler to adler2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,7 +553,7 @@ checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 name = "nod"
 version = "2.0.0-alpha.3"
 dependencies = [
- "adler",
+ "adler2",
  "aes",
  "base16ct",
  "bytes",

--- a/nod/Cargo.toml
+++ b/nod/Cargo.toml
@@ -18,13 +18,13 @@ categories = ["command-line-utilities", "parser-implementations"]
 default = ["compress-bzip2", "compress-lzma", "compress-zlib", "compress-zstd"]
 compress-bzip2 = ["bzip2"]
 compress-lzma = ["liblzma", "liblzma-sys"]
-compress-zlib = ["adler", "miniz_oxide"]
+compress-zlib = ["adler2", "miniz_oxide"]
 compress-zstd = ["zstd", "zstd-safe"]
 openssl = ["dep:openssl"]
 openssl-vendored = ["openssl", "openssl/vendored"]
 
 [dependencies]
-adler = { version = "1.0", optional = true }
+adler2 = { version = "2.0", optional = true }
 aes = "0.9.0-rc.0"
 base16ct = "0.2"
 bytes = "1.10"
@@ -52,3 +52,4 @@ xxhash-rust = { version = "0.8", features = ["xxh64"] }
 zerocopy = { workspace = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 zstd-safe = { version = "7.2", optional = true, default-features = false }
+

--- a/nod/src/io/gcz.rs
+++ b/nod/src/io/gcz.rs
@@ -4,8 +4,7 @@ use std::{
     mem::size_of,
     sync::Arc,
 };
-
-use adler::adler32_slice;
+use adler2::adler32_slice;
 use bytes::{BufMut, Bytes, BytesMut};
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, little_endian::*};
 


### PR DESCRIPTION
The original adler crate is [unmaintained](https://github.com/rustsec/advisory-db/blob/main/crates/adler/RUSTSEC-2025-0056.md). This PR replaces it with adler2, which should be a drop in replacement