### PR TITLE
nodtool: Add scrubbing option

### DIFF
--- a/nodtool/src/cmd/convert.rs
+++ b/nodtool/src/cmd/convert.rs
@@ -34,6 +34,9 @@ pub struct Args {
     #[argp(option, short = 'c')]
     /// compression format and level (e.g. "zstd:19")
     compress: Option<String>,
+    #[argp(switch, short = 's')]
+    /// performs scrubbing on the disc image
+    scrub: bool,
 }
 
 pub fn run(args: Args) -> nod::Result<()> {
@@ -85,5 +88,5 @@ pub fn run(args: Args) -> nod::Result<()> {
     compression.validate_level()?;
     let format_options =
         FormatOptions { format, compression, block_size: format.default_block_size() };
-    convert_and_verify(&args.file, Some(&args.out), args.md5, &options, &format_options)
+    convert_and_verify(&args.file, Some(&args.out), args.md5, args.scrub, &options, &format_options)
 }

--- a/nodtool/src/cmd/verify.rs
+++ b/nodtool/src/cmd/verify.rs
@@ -50,7 +50,7 @@ pub fn run(args: Args) -> nod::Result<()> {
     };
     let format_options = FormatOptions::default();
     for file in &args.file {
-        convert_and_verify(file, None, args.md5, &options, &format_options)?;
+        convert_and_verify(file, None, args.md5, false, &options, &format_options)?;
         println!();
     }
     Ok(())

--- a/nodtool/src/util/shared.rs
+++ b/nodtool/src/util/shared.rs
@@ -46,6 +46,7 @@ pub fn convert_and_verify(
     in_file: &Path,
     out_file: Option<&Path>,
     md5: bool,
+    scrub: bool,
     options: &DiscOptions,
     format_options: &FormatOptions,
 ) -> Result<()> {
@@ -128,7 +129,10 @@ pub fn convert_and_verify(
             digest_md5: md5,
             digest_sha1: true,
             digest_xxh64: true,
-            scrub: ScrubLevel::None,
+            scrub: match scrub {
+                true => ScrubLevel::UpdatePartition,
+                false => ScrubLevel::None,
+            },
         },
     )?;
     pb.finish();


### PR DESCRIPTION
This exposes the scrubbing functionality of nod into nodtool if you want to remove the update partition of Wii games when converted to `.ciso` or `.wbfs` files. This has been tested and compared to the implementation used in TinyWiiBackupManager and both produce identical results. To use the scrubbing, either use `--scrub` or `-s` when using the convert command. Here's some screenshots of the command in action:

<img width="1336" height="449" alt="image" src="https://github.com/user-attachments/assets/1b10aa6a-d7a1-4b99-910a-c3a76466b804" />

<img width="1332" height="455" alt="image" src="https://github.com/user-attachments/assets/03497b0d-a449-43f1-a08d-8fb3e288ffc6" />

<img width="857" height="432" alt="image" src="https://github.com/user-attachments/assets/f3569b26-128a-4162-97ac-c2e892f4d2f0" />

Closes #10