### PR TITLE
fix(rvz): ensure groups table compression buffer is bounded

### DIFF
--- a/nod/src/io/wia.rs
+++ b/nod/src/io/wia.rs
@@ -1830,6 +1830,13 @@ impl DiscWriter for DiscWriterWIA {
             }
             Cow::Owned(groups_buf)
         };
+        // RVZ can emit a groups table that compresses slightly above the initial
+        // header-sized reservation. Ensure the output buffer is large enough for
+        // the codec bound before attempting compression.
+        let groups_bound = compress_bound(self.compression, groups_data.len());
+        if compressor.buffer.capacity() < groups_bound {
+            compressor.buffer = Vec::with_capacity(groups_bound);
+        }
         if !compressor.compress(groups_data.as_ref()).context("Compressing groups")? {
             return Err(Error::Other("Failed to compress groups".to_string()));
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly"
-components = ["rustfmt"]


### PR DESCRIPTION
## Problem

RVZ creation could fail with: `Failed to compress groups`

- I was compressing an iso to an RVZ with `zstd` compression at level `19` and the default dolphin block size (`131072b`) 
- The same input settings in dolphin-tool or the dolphin ui worked fine

## Validation

- RVZ compress with `zstd` at level `19` with `131072b` block size now succeeds.