### PR TITLE
Fix vendored crates archive format, fix build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -246,7 +246,7 @@ jobs:
           set -eou pipefail
           mkdir .cargo
           cargo vendor-filterer > .cargo/config.toml
-          find .cargo vendor -type f | tar -czvf vendored-crates.tar.zst -T -
+          find .cargo vendor -type f | tar -cavf vendored-crates.tar.zst -T -
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,7 @@ ignore = [
 allow = [
     "0BSD",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",


### PR DESCRIPTION
It turns out that I was just creating an archive with a .zst extension that was actually still gzip-format.

Ref: https://github.com/ReillyBrogan/dusklight-flatpak/issues/1